### PR TITLE
feat(metrics): add histogram for HTTP request duration

### DIFF
--- a/src/runtime/metrics/client.ts
+++ b/src/runtime/metrics/client.ts
@@ -1,4 +1,10 @@
-import { Counter, Gauge, collectDefaultMetrics, register } from "prom-client";
+import {
+  Counter,
+  Gauge,
+  Histogram,
+  collectDefaultMetrics,
+  register,
+} from "prom-client";
 
 collectDefaultMetrics({ register });
 
@@ -12,6 +18,12 @@ const defaultMetrics = {
     name: "http_request_duration_seconds",
     help: "Duration of HTTP requests in seconds",
     labelNames: ["method", "route", "status_code"] as const,
+  }),
+  httpRequestDurationHistogram: new Histogram({
+    name: "http_request_duration_seconds_histogram",
+    help: "Duration of HTTP requests in seconds",
+    labelNames: ["method", "route", "status_code"] as const,
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
   }),
   activeRequests: new Gauge({
     name: "http_active_requests",
@@ -29,6 +41,14 @@ function collectMetrics(
     status_code: labels.statusCode,
   });
   defaultMetrics.httpRequestDuration.set(
+    {
+      method: labels.method,
+      route: labels.route,
+      status_code: labels.statusCode,
+    },
+    duration,
+  );
+  defaultMetrics.httpRequestDurationHistogram.observe(
     {
       method: labels.method,
       route: labels.route,

--- a/src/runtime/metrics/client.ts
+++ b/src/runtime/metrics/client.ts
@@ -8,23 +8,47 @@ import {
 
 collectDefaultMetrics({ register });
 
+function normalizeRoute(route: string): string {
+  let normalized = route.replace(/\/\d+/g, "/{id}");
+
+  normalized = normalized.replace(
+    /\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+    "/{uuid}",
+  );
+
+  return normalized;
+}
+
+function getStatusClass(statusCode: number): string {
+  if (statusCode >= 200 && statusCode < 300) {
+    return "2xx";
+  }
+  if (statusCode >= 300 && statusCode < 400) {
+    return "3xx";
+  }
+  if (statusCode >= 400 && statusCode < 500) {
+    return "4xx";
+  }
+  if (statusCode >= 500) {
+    return "5xx";
+  }
+  return "unknown";
+}
+
 const defaultMetrics = {
   httpRequestTotal: new Counter({
     name: "http_request_total",
     help: "Total number of HTTP requests",
     labelNames: ["method", "route", "status_code"] as const,
   }),
-  httpRequestDuration: new Gauge({
+
+  httpRequestDuration: new Histogram({
     name: "http_request_duration_seconds",
     help: "Duration of HTTP requests in seconds",
-    labelNames: ["method", "route", "status_code"] as const,
+    labelNames: ["method", "route", "status_class"] as const,
+    buckets: [0.1, 0.5, 1, 2.5, 5, 10],
   }),
-  httpRequestDurationHistogram: new Histogram({
-    name: "http_request_duration_seconds_histogram",
-    help: "Duration of HTTP requests in seconds",
-    labelNames: ["method", "route", "status_code"] as const,
-    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
-  }),
+
   activeRequests: new Gauge({
     name: "http_active_requests",
     help: "Number of active HTTP requests",
@@ -35,24 +59,20 @@ function collectMetrics(
   labels: { method: string; route: string; statusCode: number },
   duration: number,
 ) {
+  const normalizedRoute = normalizeRoute(labels.route);
+  const statusClass = getStatusClass(labels.statusCode);
+
   defaultMetrics.httpRequestTotal.inc({
     method: labels.method,
-    route: labels.route,
+    route: normalizedRoute,
     status_code: labels.statusCode,
   });
-  defaultMetrics.httpRequestDuration.set(
+
+  defaultMetrics.httpRequestDuration.observe(
     {
       method: labels.method,
-      route: labels.route,
-      status_code: labels.statusCode,
-    },
-    duration,
-  );
-  defaultMetrics.httpRequestDurationHistogram.observe(
-    {
-      method: labels.method,
-      route: labels.route,
-      status_code: labels.statusCode,
+      route: normalizedRoute,
+      status_class: statusClass,
     },
     duration,
   );


### PR DESCRIPTION
feat(metrics): add histogram support for HTTP request duration
Протестировать не знаю как, но эта метрика очень нужна.